### PR TITLE
Fix analog/digital reporting + i2c timeout

### DIFF
--- a/examples/Telemetrix4Arduino/Telemetrix4Arduino.ino
+++ b/examples/Telemetrix4Arduino/Telemetrix4Arduino.ino
@@ -888,7 +888,6 @@ void scan_analog_inputs()
   // byte 4 = low order byte of value
 
   byte report_message[5] = {4, ANALOG_REPORT, 0, 0, 0};
-  send_debug_info(1,1);
   uint8_t adjusted_pin_number;
   int differential;
 
@@ -896,16 +895,12 @@ void scan_analog_inputs()
   if (current_millis - previous_millis > analog_sampling_interval)
   {
     previous_millis += analog_sampling_interval;
-send_debug_info(1,2);
     for (int i = 0; i < MAX_ANALOG_PINS_SUPPORTED; i++)
     {
-      send_debug_info(1,3);
       if (the_analog_pins[i].pin_mode == AT_ANALOG)
       {
-        send_debug_info(1,4);
         if (the_analog_pins[i].reporting_enabled)
         {
-          send_debug_info(1,5);
           // if the value changed since last read
           // adjust pin number for the actual read
           adjusted_pin_number = (uint8_t)(analog_read_pins[i]);
@@ -919,7 +914,6 @@ send_debug_info(1,2);
             report_message[2] = (byte)i;
             report_message[3] = highByte(value); // get high order byte
             report_message[4] = lowByte(value);
-            send_debug_info(1,6);
             Serial.write(report_message, 5);
             delay(1);
           }

--- a/examples/Telemetrix4Arduino/Telemetrix4Arduino.ino
+++ b/examples/Telemetrix4Arduino/Telemetrix4Arduino.ino
@@ -584,15 +584,19 @@ void servo_detach()
 void i2c_begin()
 {
   byte i2c_port = command_buffer[0];
-  if (not i2c_port)
+  if (! i2c_port)
   {
     Wire.begin();
+    Wire.setWireTimeout(10,false);
+    Wire.clearWireTimeoutFlag();
   }
 
 #ifdef SECOND_I2C_PORT
   else
   {
     Wire2.begin();
+    Wire2.setWireTimeout(10,false);
+    Wire2.clearWireTimeoutFlag();
   }
 #endif
 }
@@ -694,7 +698,9 @@ void i2c_write()
     current_i2c_port = &Wire2;
   }
 #endif
-
+  if(current_i2c_port->getWireTimeoutFlag()) {
+    return;
+  }
   current_i2c_port->beginTransmission(command_buffer[1]);
 
   // write the data to the device
@@ -703,7 +709,7 @@ void i2c_write()
     current_i2c_port->write(command_buffer[i + 3]);
   }
   current_i2c_port->endTransmission();
-  delayMicroseconds(70);
+  // delayMicroseconds(70);
 }
 
 /***********************************
@@ -799,14 +805,14 @@ void get_next_command()
   memset(command_buffer, 0, sizeof(command_buffer));
 
   // if there is no command waiting, then return
-  if (not Serial.available())
+  if (! Serial.available())
   {
     return;
   }
   // get the packet length
   packet_length = (byte)Serial.read();
 
-  while (not Serial.available())
+  while (! Serial.available())
   {
     delay(1);
   }
@@ -824,7 +830,7 @@ void get_next_command()
     for (int i = 0; i < packet_length - 1; i++)
     {
       // need this delay or data read is not correct
-      while (not Serial.available())
+      while (! Serial.available())
       {
         delay(1);
       }

--- a/examples/Telemetrix4Arduino/Telemetrix4Arduino.ino
+++ b/examples/Telemetrix4Arduino/Telemetrix4Arduino.ino
@@ -882,7 +882,7 @@ void scan_analog_inputs()
   // byte 4 = low order byte of value
 
   byte report_message[5] = {4, ANALOG_REPORT, 0, 0, 0};
-
+  send_debug_info(1,1);
   uint8_t adjusted_pin_number;
   int differential;
 
@@ -890,13 +890,16 @@ void scan_analog_inputs()
   if (current_millis - previous_millis > analog_sampling_interval)
   {
     previous_millis += analog_sampling_interval;
-
+send_debug_info(1,2);
     for (int i = 0; i < MAX_ANALOG_PINS_SUPPORTED; i++)
     {
+      send_debug_info(1,3);
       if (the_analog_pins[i].pin_mode == AT_ANALOG)
       {
+        send_debug_info(1,4);
         if (the_analog_pins[i].reporting_enabled)
         {
+          send_debug_info(1,5);
           // if the value changed since last read
           // adjust pin number for the actual read
           adjusted_pin_number = (uint8_t)(analog_read_pins[i]);
@@ -910,6 +913,7 @@ void scan_analog_inputs()
             report_message[2] = (byte)i;
             report_message[3] = highByte(value); // get high order byte
             report_message[4] = lowByte(value);
+            send_debug_info(1,6);
             Serial.write(report_message, 5);
             delay(1);
           }

--- a/examples/Telemetrix4Arduino/Telemetrix4Arduino.ino
+++ b/examples/Telemetrix4Arduino/Telemetrix4Arduino.ino
@@ -391,11 +391,13 @@ void set_pin_mode()
     case INPUT:
       the_digital_pins[pin].pin_mode = mode;
       the_digital_pins[pin].reporting_enabled = command_buffer[2];
+      the_digital_pins[pin].last_value = -1;
       pinMode(pin, INPUT);
       break;
     case INPUT_PULLUP:
       the_digital_pins[pin].pin_mode = mode;
       the_digital_pins[pin].reporting_enabled = command_buffer[2];
+      the_digital_pins[pin].last_value = -1;
       pinMode(pin, INPUT_PULLUP);
       break;
     case OUTPUT:
@@ -406,6 +408,7 @@ void set_pin_mode()
       the_analog_pins[pin].pin_mode = mode;
       the_analog_pins[pin].differential = (command_buffer[2] << 8) + command_buffer[3];
       the_analog_pins[pin].reporting_enabled = command_buffer[4];
+      the_analog_pins[pin].last_value = -1;
       break;
     default:
       break;


### PR DESCRIPTION
- At set_pin_mode always set the value to something it cannot be, to force trigger a read and write to the computer
- Add i2c write timeout to stop after failed write(oled) and not try at subsequent calls. Without the timeout the Arduino will be waiting (blocked) for i2c ack, which won't come when there is no oled.