### PR TITLE
Fix stm32 i2c timeout + add workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,41 @@
+name: Arduino Compile
+
+on:
+    push:
+    pull_request:
+        branches:
+            - main
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                board_fqbn: [
+                    arduino:avr:uno, 
+                    arduino:avr:nano, 
+                    STM32:stm32:GenF1:pnum=BLUEPILL_F103C8
+                  ]
+        steps:
+            - name: setup path
+              run: |
+                echo "/root/.local/bin" >> $GITHUB_PATH
+                git clone https://github.com/mirte-robot/mirte-arduino-libraries.git
+            - name: Checkout repository
+              uses: actions/checkout@v2
+            - uses: arduino/compile-sketches@v1
+              with:
+                  cli-version: 0.13.0
+                  fqbn: "${{ matrix.board_fqbn }}"
+                  platforms: |
+                    - name: STM32:stm32
+                      source-url: https://raw.githubusercontent.com/koendv/stm32duino-raspberrypi/master/BoardManagerFiles/package_stm_index.json
+                    - name: arduino:avr
+                  libraries: |
+                    - name: Servo
+                    - name: Stepper
+                    - name: DHTNEW
+                    - name: NewPing
+                    - source-path: ./mirte-arduino-libraries/OpticalEncoder
+                    - source-path: ./
+                  sketch-paths: examples/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,9 +12,9 @@ jobs:
         strategy:
             matrix:
                 board_fqbn: [
-                    arduino:avr:uno, 
-                    arduino:avr:nano, 
-                    STM32:stm32:GenF1:pnum=BLUEPILL_F103C8
+                    "arduino:avr:uno", 
+                    "arduino:avr:nano", 
+                    "STM32:stm32:GenF1:pnum=BLUEPILL_F103C8"
                   ]
         steps:
             - name: setup path

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,9 +20,10 @@ jobs:
             - name: setup path
               run: |
                 echo "/root/.local/bin" >> $GITHUB_PATH
+                cd /root/
                 git clone https://github.com/mirte-robot/mirte-arduino-libraries.git
             - name: Checkout repository
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
             - uses: arduino/compile-sketches@v1
               with:
                   cli-version: 0.13.0
@@ -36,6 +37,7 @@ jobs:
                     - name: Stepper
                     - name: DHTNEW
                     - name: NewPing
-                    - source-path: ./mirte-arduino-libraries/OpticalEncoder
+                    - source-path: /root/mirte-arduino-libraries/OpticalEncoder
                     - source-path: ./
                   sketch-paths: examples/
+                  verbose: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,14 +16,17 @@ jobs:
                     "arduino:avr:nano", 
                     "STM32:stm32:GenF1:pnum=BLUEPILL_F103C8"
                   ]
+            fail-fast: false
         steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
             - name: setup path
               run: |
                 echo "/root/.local/bin" >> $GITHUB_PATH
-                cd /root/
+                mkdir libs
+                cd libs
                 git clone https://github.com/mirte-robot/mirte-arduino-libraries.git
-            - name: Checkout repository
-              uses: actions/checkout@v4
+                cd ..
             - uses: arduino/compile-sketches@v1
               with:
                   cli-version: 0.13.0
@@ -37,7 +40,7 @@ jobs:
                     - name: Stepper
                     - name: DHTNEW
                     - name: NewPing
-                    - source-path: /root/mirte-arduino-libraries/OpticalEncoder
+                    - source-path: ./libs/mirte-arduino-libraries/OpticalEncoder
                     - source-path: ./
                   sketch-paths: examples/
                   verbose: true

--- a/examples/Telemetrix4Arduino/Telemetrix4Arduino.ino
+++ b/examples/Telemetrix4Arduino/Telemetrix4Arduino.ino
@@ -587,16 +587,20 @@ void i2c_begin()
   if (! i2c_port)
   {
     Wire.begin();
+#if defined(__AVR_ATmega328P__) 
     Wire.setWireTimeout(10,false);
     Wire.clearWireTimeoutFlag();
+#endif
   }
 
 #ifdef SECOND_I2C_PORT
   else
   {
     Wire2.begin();
+#if defined(__AVR_ATmega328P__) 
     Wire2.setWireTimeout(10,false);
     Wire2.clearWireTimeoutFlag();
+#endif
   }
 #endif
 }
@@ -698,9 +702,12 @@ void i2c_write()
     current_i2c_port = &Wire2;
   }
 #endif
-  if(current_i2c_port->getWireTimeoutFlag()) {
+#if defined(__AVR_ATmega328P__) 
+  if (current_i2c_port->getWireTimeoutFlag())
+  {
     return;
   }
+#endif
   current_i2c_port->beginTransmission(command_buffer[1]);
 
   // write the data to the device


### PR DESCRIPTION
The used functions are not available on the stm32 platform. This adds a #if guard around them to at least compile.
The workflow checks all the supported hardware platforms that it compiles.