### PR TITLE
Fix encoder spamming usb buff, set to 100Hz

### DIFF
--- a/examples/Telemetrix4Arduino/Telemetrix4Arduino.ino
+++ b/examples/Telemetrix4Arduino/Telemetrix4Arduino.ino
@@ -357,7 +357,7 @@ intCB interruptMap[MAX_ENCODERS] = {
 
 unsigned long optenc_current_millis;      // for analog input loop
 unsigned long optenc_previous_millis;     // for analog input loop
-unsigned int optenc_scan_interval = 0; // scan encoders every x ms
+unsigned int optenc_scan_interval = 10; // scan encoders every x ms
 
 // buffer to hold incoming command data
 byte command_buffer[MAX_COMMAND_LENGTH];
@@ -1102,9 +1102,9 @@ void reset_data() {
 
   // Reset optical encoder timers and index
   optEncoder_ix = 0;
-  optenc_current_millis = 0;      // for analog input loop
-  optenc_previous_millis = 0;     // for analog input loop
-  optenc_scan_interval = 0; // scan encoders every x ms
+  optenc_current_millis = 0;      // for encoder input loop
+  optenc_previous_millis = millis();     // for encoder input loop
+  optenc_scan_interval = 10; // scan encoders every x ms
 
   init_pin_structures();
 


### PR DESCRIPTION
Old situation: on every encoder change (new pulse), it would be sent to the computer

New situation: every 10ms and on encoder change, send to computer

When the rate would be too high, the usb buffer would overflow and everything would crash